### PR TITLE
Feat/courses format

### DIFF
--- a/src/router/scraping.rs
+++ b/src/router/scraping.rs
@@ -51,12 +51,12 @@ async fn publish_free_courses(
         })
         .collect::<Vec<CreateEmbed>>();
 
-    let courses = embeds.chunks(course_chunk_size);
+    let courses_embeds_chunks = embeds.chunks(course_chunk_size);
 
     let mut errors = 0;
     let mut current_chunk = 1;
 
-    for courses_message in courses.into_iter() {
+    for embeds in courses_embeds_chunks.into_iter() {
         let text_content = if current_chunk == 1 {
             Some("@here\n# Cursos gratis de la semana 🦊🚬\n".to_string())
         } else {
@@ -66,7 +66,7 @@ async fn publish_free_courses(
         let send_response = utils::send_embeds_to_channel(
             &ctx.0,
             consts::COURSES_CHANNEL_ID,
-            courses_message.to_vec(),
+            embeds.to_vec(),
             text_content,
         )
         .await;

--- a/src/router/scraping.rs
+++ b/src/router/scraping.rs
@@ -5,7 +5,7 @@ use axum::{extract::State, response::IntoResponse};
 use axum::{Json, Router};
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
-use serenity::all::ChannelId;
+use serenity::all::{ChannelId, Colour, CreateEmbed};
 use tracing::{error, info};
 
 pub type FreeCourses = Vec<FreeCourse>;
@@ -39,35 +39,35 @@ async fn publish_free_courses(
     let course_chunk_size = 5;
     let total_courses = body.len();
 
-    let formated_messages = body
+    let embeds = body
         .into_iter()
         .map(|free_course| {
-            format!(
-                "**{}**\nCódigo: `{}`\nTiempo para reclamar: `{}`\n🔗 [enlace]({})",
-                free_course.title, free_course.code, free_course.countdown, free_course.link,
-            )
+            CreateEmbed::new()
+                .title(format!("**{}**", free_course.title))
+                .field("**Código**", free_course.code, true)
+                .field("**Tiempo para reclamar**", free_course.countdown, true)
+                .url(free_course.link)
+                .color(Colour::from_rgb(15, 137, 64))
         })
-        .collect::<Vec<String>>();
+        .collect::<Vec<CreateEmbed>>();
 
-    let courses = formated_messages.chunks(course_chunk_size);
+    let courses = embeds.chunks(course_chunk_size);
 
     let mut errors = 0;
     let mut current_chunk = 1;
 
-    for courses_message in courses {
-        let msg = courses_message.join("\n\n");
-
-        let formated_message = if current_chunk == 1 {
-            format!("@here\n\n**Cursos gratis de la semana**\n\n{msg}")
+    for courses_message in courses.into_iter() {
+        let text_content = if current_chunk == 1 {
+            Some("@here\n# Cursos gratis de la semana 🦊🚬\n".to_string())
         } else {
-            format!("_\n\n{msg}")
+            None
         };
 
-        let send_response = utils::send_message_to_channel(
+        let send_response = utils::send_embeds_to_channel(
             &ctx.0,
             consts::COURSES_CHANNEL_ID,
-            formated_message,
-            None,
+            courses_message.to_vec(),
+            text_content,
         )
         .await;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
 use serenity::all::{
-    ChannelId, CreateAttachment, CreateMessage, Http, ResolvedOption, ResolvedValue, StickerId,
-    User,
+    ChannelId, CreateAttachment, CreateEmbed, CreateMessage, Http, ResolvedOption, ResolvedValue,
+    StickerId, User,
 };
 use tracing::{error, info};
 
@@ -32,6 +32,33 @@ pub async fn send_message_to_channel(
     if let Some(sticker) = sticker_id {
         message = message.sticker_id(StickerId::new(sticker));
     }
+
+    if let Err(err) = channel.send_message(http, message).await {
+        error!("Error on send message: {err}");
+
+        return Err(err);
+    }
+
+    info!("Message was sending to channel");
+
+    Ok(())
+}
+
+pub async fn send_embeds_to_channel(
+    http: &Http,
+    channel_id: u64,
+    embeds: Vec<CreateEmbed>,
+    content: Option<String>,
+) -> Result<(), serenity::Error> {
+    let channel = ChannelId::new(channel_id);
+
+    let mut message = CreateMessage::new();
+
+    if let Some(txt) = content {
+        message = message.content(txt);
+    }
+
+    message = message.add_embeds(embeds);
 
     if let Err(err) = channel.send_message(http, message).await {
         error!("Error on send message: {err}");


### PR DESCRIPTION
## Cambios
Se han cambiado el formato del mensaje de cursos de string a embebidos:

<img width="636" alt="image" src="https://github.com/user-attachments/assets/5f7b6e6d-2355-4f6f-b6c8-03120abdecf1">
 